### PR TITLE
fix bug that will not check changed files if changed file count > 30

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,0 @@
-# Test Template
-
-#### Test Options
-
-- [ ] Option 1
-- [ ] Option 2

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -25,6 +25,7 @@ describe('Smoke test', () => {
   beforeEach(() => {
     envCache = process.env
     process.env = {}
+    process.env.NODE_ENV = 'test'
     process.env.BUILD_REPOSITORY_ID = REPO_ID
     process.env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER = PR_NUMBER
     process.env.BUILD_REPOSITORY_PROVIDER = 'GitHub'

--- a/tests/unit/changedFiles.mjs
+++ b/tests/unit/changedFiles.mjs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import assert from 'node:assert/strict'
+import nock from 'nock'
 
 import { setEnv, nockInit, REPO_ID, PR_NUMBER } from '../utils.mjs'
 import { fileChangeCheck, ENV_VARS } from '../../src/core.mjs'
@@ -12,12 +13,14 @@ describe('Changed files check', () => {
   beforeEach(() => {
     envCache = process.env
     process.env = {}
+    process.env.NODE_ENV = 'test'
     process.env.BUILD_REPOSITORY_ID = REPO_ID
     process.env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER = PR_NUMBER
   })
 
   afterEach(() => {
     process.env = envCache
+    nock.cleanAll()
   })
 
   it('should skip if glob is not provided', async () => {
@@ -34,5 +37,39 @@ describe('Changed files check', () => {
     setEnv(ENV_VARS.fileChangeGlobs, '**/asd.js')
     nockInit({}, ['a.txt', 'a/b/c/d/asd.py', 'b.js'])
     assert(!await fileChangeCheck())
+  })
+
+  it('should continue if any changed file matches the pattern (multiple pages)', async () => {
+    setEnv(ENV_VARS.fileChangeGlobs, '**/asd.js')
+    const list = []
+    for (let i = 0; i < 301; i++) {
+      list.push(`${i}.txt`)
+    }
+    list.push('a/b/c/d/asd.js')
+    for (let i = 0; i < 301; i++) {
+      list.push(`${i}.txt`)
+    }
+    nockInit({}, list)
+    assert(await fileChangeCheck())
+  })
+
+  it('should skip if no changed files matches the pattern (multiple pages)', async () => {
+    setEnv(ENV_VARS.fileChangeGlobs, '**/asd.js')
+    const list = []
+    for (let i = 0; i < 301; i++) {
+      list.push(`${i}.txt`)
+    }
+    nockInit({}, list)
+    assert(!await fileChangeCheck())
+  })
+
+  it('should continue if changed files > 3000', async () => {
+    setEnv(ENV_VARS.fileChangeGlobs, '**/asd.js')
+    const list = []
+    for (let i = 0; i < 3001; i++) {
+      list.push(`${i}.txt`)
+    }
+    nockInit({}, list)
+    assert(await fileChangeCheck())
   })
 })

--- a/tests/unit/prbody.mjs
+++ b/tests/unit/prbody.mjs
@@ -13,6 +13,7 @@ describe('Pull request body check', () => {
   beforeEach(() => {
     envCache = process.env
     process.env = {}
+    process.env.NODE_ENV = 'test'
     process.env.BUILD_REPOSITORY_ID = REPO_ID
     process.env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER = PR_NUMBER
   })

--- a/tests/utils.mjs
+++ b/tests/utils.mjs
@@ -19,13 +19,14 @@ const nockInit = (options, changedFiles) => {
   textOptions = textOptions.join('')
   nock('https://api.github.com')
     .get(`/repos/${REPO_ID}/pulls/${PR_NUMBER}`)
-    .reply(200, { body: `# Test Template\r\n\r\n${MARKDOWN_HEADING}\r\n\r\n${textOptions}` })
+    .reply(200, { body: `# Test Template\r\n\r\n${MARKDOWN_HEADING}\r\n\r\n${textOptions}`, changed_files: changedFiles.length })
 
-  changedFiles = changedFiles || []
-
-  nock('https://api.github.com')
-    .get(`/repos/${REPO_ID}/pulls/${PR_NUMBER}/files`)
-    .reply(200, changedFiles.map(x => ({ filename: x })))
+  for (let offset = 0, i = 1; offset < changedFiles.length; offset += 100, i += 1) {
+    nock('https://api.github.com')
+      .get(`/repos/${REPO_ID}/pulls/${PR_NUMBER}/files`)
+      .query({ per_page: 100, page: i })
+      .reply(200, changedFiles.slice(offset, offset + 100).map(x => ({ filename: x })))
+  }
 }
 
 export { setEnv, nockInit, REPO_ID, PR_NUMBER, MARKDOWN_HEADING }


### PR DESCRIPTION
- fix bug that will not check changed files if changed file count > 30
  - by default, github api only returns 30 files in one page.
- due to github rest api's limitation, will continue when changed file count > 3000
  - https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files